### PR TITLE
Attempt B

### DIFF
--- a/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
+++ b/services/api-db/docker-entrypoint-initdb.d/00-tables.sql
@@ -272,3 +272,11 @@ CREATE TABLE IF NOT EXISTS task_file (
   fid int REFERENCES file (id),
   CONSTRAINT task_file_pkey PRIMARY KEY (tid, fid)
 );
+
+CREATE TABLE cache_authz (
+  id int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `key` varchar(300) NOT NULL DEFAULT '',
+  allowed tinyint(1) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE `key` (`key`)
+);

--- a/services/api/src/apolloServer.js
+++ b/services/api/src/apolloServer.js
@@ -78,7 +78,7 @@ const apolloServer = new ApolloServer({
         keycloakAdminClient,
         sqlClient,
         hasPermission: grant
-          ? keycloakHasPermission(grant, requestCache, keycloakAdminClient)
+          ? keycloakHasPermission(grant, requestCache, keycloakAdminClient, sqlClient)
           : legacyHasPermission(legacyCredentials),
         keycloakGrant: grant,
         requestCache,
@@ -132,7 +132,8 @@ const apolloServer = new ApolloServer({
           ? keycloakHasPermission(
               req.kauth.grant,
               requestCache,
-              keycloakAdminClient
+              keycloakAdminClient,
+              sqlClient
             )
           : legacyHasPermission(req.legacyCredentials),
         keycloakGrant: req.kauth ? req.kauth.grant : null,


### PR DESCRIPTION
Use user ids as key, store permissions data as JSON.

Doesn't work with asynchronous apollo resolvers (last cache update overwrites JSON of other resolvers, so cache doesn't get "full" at first run)